### PR TITLE
In call to Qc3GenPRNS: Proper check of exception

### DIFF
--- a/src/bsdcompat.c
+++ b/src/bsdcompat.c
@@ -19,6 +19,7 @@ typedef struct {
 	int bytes_avail;
 	char exception_id[7];
 	char reserved;
+	char data[20];
 } ERRC0100;
 
 void arc4random_buf(void *buf, size_t nbytes)
@@ -30,7 +31,7 @@ void arc4random_buf(void *buf, size_t nbytes)
 	 * UTF locale, use EBCDIC in hex.
 	 */
 	Qc3GenPRNs(buf, nbytes, 0xf0, 0xf0, &error);
-	if (error.exception_id[0] != '\0') {
+	if (error.bytes_avail != 0) {
 		/* XXX: We're in UTF-8 ILE world, but XPF still returns EBCDIC */
 		fprintf(stderr, " ** arc4random_buf should never fail");
 		abort();


### PR DESCRIPTION
According to IBM: bytes_avail is 0 if no error was detected.

See https://www.ibm.com/docs/en/i/7.4?topic=parameter-error-code-format. The error struct is an automatic variable, so contains  random stack bytes upon initialization.


